### PR TITLE
Upgrade nodejs to LTS

### DIFF
--- a/images/common/cli/Dockerfile
+++ b/images/common/cli/Dockerfile
@@ -12,40 +12,18 @@ RUN mkdir -p /tmp/blackfire \
 
 ENV PATH=/data/vendor/bin:$PATH
 
+# Node.js Binary Distribution from NodeSource
+# https://github.com/nodesource/distributions/blob/master/README.md
+RUN curl -fsSL https://deb.nodesource.com/setup_lts.x | bash
+
 RUN --mount=type=cache,id=aptlib,sharing=locked,target=/var/lib/apt \
     --mount=type=cache,id=aptcache,sharing=locked,target=/var/cache/apt \
   bash -c 'if [ ! -z "$(which apt)" ]; then apt update -y && apt install -y \
      nodejs \
-     npm \
      inotify-tools \
      netcat-openbsd \
      git \
      redis-tools \
-     ; fi'
-# Debian contains outdated Yarn package
-RUN --mount=type=cache,id=aptlib,sharing=locked,target=/var/lib/apt \
-    --mount=type=cache,id=aptcache,sharing=locked,target=/var/cache/apt \
-  bash -c 'if [ ! -z "$(which apt)" ]; then \
-     curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
-     echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
-     apt update -y && apt install -y \
-     yarn \
-     ; fi'
-# Debian contains outdated NPM package
-RUN --mount=type=cache,id=npm,sharing=locked,target=/root/.npm \
-  bash -c 'if [ ! -z "$(which apt)" ]; then npm install npm@^6.0.0 -g; fi'
-
-RUN --mount=type=cache,id=apk,sharing=locked,target=/var/cache/apk mkdir -p /etc/apk && ln -vsf /var/cache/apk /etc/apk/cache && \
-  bash -c 'if [ ! -z "$(which apk)" ]; then apk update && apk add \
-     nodejs \
-     npm \
-     inotify-tools \
-     netcat-openbsd \
-     coreutils \
-     ncurses \
-     git \
-     redis \
-     yarn \
      ; fi'
 
 # TODO Not-available feature: autoload-cache. Should be switchable


### PR DESCRIPTION
This upgrades nodejs from the very very old v10 to LTS (v16)

In the course of this I've also removed any ugly code (such as a pinned deprecated npm version) and clean up the Dockerfile a bit.

It works now locally without any problems and I've finally got my v16 in spryker shop 🎉 